### PR TITLE
Fix NoSuchElementException when backstack is empty

### DIFF
--- a/library/src/main/java/za/ampfarisaho/pathfinder/PathfinderNavigator.kt
+++ b/library/src/main/java/za/ampfarisaho/pathfinder/PathfinderNavigator.kt
@@ -34,14 +34,12 @@ class PathfinderNavigator(private val activity: ComponentActivity) : Navigator {
      */
     private fun updateCurrentScreenKey() {
         CoroutineScope(Dispatchers.Main).launch {
-            if (backStack.isNotEmpty()) {
-                (backStack.last() as? ComposeScreen)?.let { lastScreen ->
-                    _currentScreenKey.emit(lastScreen.screenKey)
-                }
+            (backStack.lastOrNull() as? ComposeScreen)?.let { lastScreen ->
+                _currentScreenKey.emit(lastScreen.screenKey)
             }
 
             snapshotFlow { backStack.toList() }.collect { snapshot ->
-                (snapshot.last() as? ComposeScreen)?.let { lastScreen ->
+                (snapshot.lastOrNull() as? ComposeScreen)?.let { lastScreen ->
                     _currentScreenKey.emit(lastScreen.screenKey)
                 }
             }


### PR DESCRIPTION
Replace `last()` with `lastOrNull()` in `PathfinderNavigator.updateCurrentScreenKey()` to prevent crashes when the navigation backstack is empty.