### PR TITLE
Expose Back Stack Size

### DIFF
--- a/library/src/main/java/za/ampfarisaho/pathfinder/PathfinderNavigator.kt
+++ b/library/src/main/java/za/ampfarisaho/pathfinder/PathfinderNavigator.kt
@@ -27,6 +27,9 @@ class PathfinderNavigator(private val activity: ComponentActivity) : Navigator {
         get() = _backStack
             ?: error("BackStack has not been initialized. Call setBackStack() first.")
 
+    val backStackSize: Int
+        get() = backStack.size
+
     private val _currentScreenKey = MutableSharedFlow<String>()
     val currentScreenKey: Flow<String> = _currentScreenKey
 


### PR DESCRIPTION
Expose the back stack size through `Navigator`. This can be useful when handling `NavDisplay`'s `onBack` callback e.g. ensure app is finished

```kotlin
PathfinderNavDisplay(
    onBack = {
        if (navigator.backStackSize > 1) {
            navigator.executeCommand(Back)
        } else {
            finish()
        }
    }
)
```